### PR TITLE
Vectorize Hamming distance computation

### DIFF
--- a/hamming_distance.m
+++ b/hamming_distance.m
@@ -1,7 +1,5 @@
-function dist=hamming_distance(a,b)
-dist=0;
-for i=1:length(a)
-    if abs(a(i)-b(i))>10^(-3)
-        dist=dist+1;
-    end
-end
+function dist = hamming_distance(a, b)
+%HAMMING_DISTANCE Count elements differing beyond a tolerance.
+% The threshold 1e-3 accounts for small numerical precision errors.
+
+dist = sum(abs(a - b) > 1e-3);


### PR DESCRIPTION
## Summary
- Replace explicit loop with vectorized `sum(abs(a - b) > 1e-3)` for efficiency
- Document 1e-3 tolerance to explain numerical precision threshold

## Testing
- `octave -qf --eval "hamming_distance([1 2],[1 2.0005])"` *(fails: command not found)*
- `matlab -batch "hamming_distance([1 2],[1 2.0005])"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a11a5365108330ad0b815963b6f9e7