### PR TITLE
Expose K and Cz_r from greedy_search

### DIFF
--- a/greedy_search.m
+++ b/greedy_search.m
@@ -1,4 +1,4 @@
-function [final_W, final_B, MSE_1] = greedy_search(B_all, alpha, n_cols, I_nr_r, Cn_r, H_r, Cx_r, n_max_comb, h, MSE_1)
+function [final_W, final_B, MSE_1, K, Cz_r] = greedy_search(B_all, alpha, n_cols, I_nr_r, Cn_r, H_r, Cx_r, n_max_comb, h, MSE_1)
 % Alpha first rows of B_all
 B_alpha = B_all(1:alpha,:);
 % Computing the MSE for the first alpha rows
@@ -71,7 +71,11 @@ for i=1:alpha
             MSE_1(h,i) = MSE_data_2;           
         end
         
-    end
-    
+      end
+
 end
+% Final Cz_r and K
+Cz_r = final_B*H_r*Cx_r*H_r'*final_B' + final_B*Cn_r*final_B';
+K = diag(diag(Cz_r).^(-1/2));
+
 end

--- a/untitled1.m
+++ b/untitled1.m
@@ -112,7 +112,7 @@ for ch = 1:channel_realizations
         C_eta_greedy = (2/pi)*(asin(Kg*Cz_greedy*Kg) - Kg*Cz_greedy*Kg) + Kg*B_greedy*Cn_r*B_greedy'*Kg;
         I_greedy(i,ch) = 0.5*log2(det(eye(2*Nr+alpha) + pinv(real(C_eta_greedy)) * ((sigma_x^2/2)*H_eff_greedy*H_eff_greedy')));
         % ---------- Greedy por MSE ----------
-        [~, B_mse, ~, K_mse, Cz_r_mse, ~] = greedy_search(B_all, alpha, 2*Nr, I_Nr_r, Cn_r, H_r, Cx_r, size(B_all,1));
+        [~, B_mse, ~, K_mse, Cz_r_mse] = greedy_search(B_all, alpha, 2*Nr, I_Nr_r, Cn_r, H_r, Cx_r, size(B_all,1));
         H_eff_mse = sqrt(2/pi)*K_mse*B_mse*H_r;
         C_eta_mse = (2/pi)*(asin(K_mse*Cz_r_mse*K_mse) - K_mse*Cz_r_mse*K_mse) + K_mse*B_mse*Cn_r*B_mse'*K_mse;
         I_greedy_mse(i,ch) = 0.5*log2(det(eye(2*Nr+alpha) + pinv(real(C_eta_mse)) * ((sigma_x^2/2)*H_eff_mse*H_eff_mse')));


### PR DESCRIPTION
## Summary
- expand greedy_search to return scaling matrix K and covariance Cz_r
- update untitled1 to use additional outputs from greedy_search

## Testing
- `octave -qf --eval "disp('test')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a118b9e8788330bf2e432f289bc0ed