### PR TITLE
Vectorize and preallocate gray code distance computations

### DIFF
--- a/gray_code.m
+++ b/gray_code.m
@@ -6,9 +6,11 @@ gray_code_data(1,:) = bit_set(1,:);
 new_bit_set=bit_set(2:end,:);
 
 for i=2:modulation_size
-    for j=1:size(new_bit_set,1)
-        dist(j) = hamming_distance(gray_code_data(i-1,:),new_bit_set(j,:));
-    end
+    % Preassign distance vector to avoid dynamic resizing
+    dist = zeros(size(new_bit_set,1),1);
+
+    % Vectorized computation of Hamming distances to all remaining codes
+    dist(:) = sum(abs(new_bit_set - gray_code_data(i-1,:)) > 1e-3, 2);
     [~,index]=min(dist);
     gray_code_data(i,:) = new_bit_set(index,:);
     
@@ -20,7 +22,7 @@ for i=2:modulation_size
             cont = cont + 1;
         end
     end
-    clear new_bit_set dist
     new_bit_set = aux;
+    dist = [];
 end
 end


### PR DESCRIPTION
## Summary
- Preallocate distance vector to avoid dynamic resizing in `gray_code`
- Vectorize Hamming distance calculation for faster minimum search
- Replace `clear` statements with explicit reassignments

## Testing
- ❌ `octave --version` (command not found)
- ⚠️ `apt-get update` (403 errors, repository not signed)
- ❌ `matlab -batch "gray_code([0 1;1 0],2)"` (command not found)


------
https://chatgpt.com/codex/tasks/task_b_68a118bed06c83309a396b4f310dfbd1