### PR TITLE
Simplify greedy_search parameters and usage

### DIFF
--- a/greedy_search.m
+++ b/greedy_search.m
@@ -1,4 +1,4 @@
-function [final_W, final_B, MSE_1, K, Cz_r] = greedy_search(B_all, alpha, n_cols, I_nr_r, Cn_r, H_r, Cx_r, n_max_comb, h, MSE_1)
+function [final_W, final_B, K, Cz_r] = greedy_search(B_all, alpha, I_nr_r, Cn_r, H_r, Cx_r, n_max_comb)
 % Alpha first rows of B_all
 B_alpha = B_all(1:alpha,:);
 % Computing the MSE for the first alpha rows
@@ -52,7 +52,6 @@ for i=1:alpha
         
         %total MSE
         MSE_data_2 = trace(Cx_r) - 2*real(trace(Czqx*W')) + trace(W*Czq*W');
-        MSE_this(h,i) = MSE_data_2; 
         
         % Checking if the curent MSE is the minimum
         if MSE_data < lower_value
@@ -68,7 +67,6 @@ for i=1:alpha
         
         if MSE_data_2 < lower_value_2
             lower_value_2 = MSE_data_2;
-            MSE_1(h,i) = MSE_data_2;           
         end
         
       end

--- a/untitled1.m
+++ b/untitled1.m
@@ -112,7 +112,7 @@ for ch = 1:channel_realizations
         C_eta_greedy = (2/pi)*(asin(Kg*Cz_greedy*Kg) - Kg*Cz_greedy*Kg) + Kg*B_greedy*Cn_r*B_greedy'*Kg;
         I_greedy(i,ch) = 0.5*log2(det(eye(2*Nr+alpha) + pinv(real(C_eta_greedy)) * ((sigma_x^2/2)*H_eff_greedy*H_eff_greedy')));
         % ---------- Greedy por MSE ----------
-        [~, B_mse, ~, K_mse, Cz_r_mse] = greedy_search(B_all, alpha, 2*Nr, I_Nr_r, Cn_r, H_r, Cx_r, size(B_all,1));
+        [~, B_mse, K_mse, Cz_r_mse] = greedy_search(B_all, alpha, I_Nr_r, Cn_r, H_r, Cx_r, size(B_all,1));
         H_eff_mse = sqrt(2/pi)*K_mse*B_mse*H_r;
         C_eta_mse = (2/pi)*(asin(K_mse*Cz_r_mse*K_mse) - K_mse*Cz_r_mse*K_mse) + K_mse*B_mse*Cn_r*B_mse'*K_mse;
         I_greedy_mse(i,ch) = 0.5*log2(det(eye(2*Nr+alpha) + pinv(real(C_eta_mse)) * ((sigma_x^2/2)*H_eff_mse*H_eff_mse')));


### PR DESCRIPTION
## Summary
- Remove unused parameters `n_cols`, `h`, and `MSE_1` from `greedy_search` and clean up related logic.
- Update `untitled1` to call `greedy_search` using the simplified signature.

## Testing
- `octave --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y octave` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_68a11ebb90c08330a55b6387638533c6