### PR TITLE
Remove unused n_comb parameter from permutation helpers

### DIFF
--- a/get_all_perm.m
+++ b/get_all_perm.m
@@ -1,8 +1,7 @@
-function m_comb = get_all_perm(n_comb, cols)
+function m_comb = get_all_perm(cols)
 %GET_ALL_PERM Generate all unique pair combinations
-%   m_comb = GET_ALL_PERM(n_comb, cols) returns all unique combinations
-%   of two indices from 1 to cols. The input n_comb is kept for
-%   compatibility but is not used in the computation.
+%   m_comb = GET_ALL_PERM(cols) returns all unique combinations
+%   of two indices from 1 to cols.
 
 % Generate all combinations of two indices without explicit loops
 m_comb = nchoosek(1:cols, 2);

--- a/get_random_perm.m
+++ b/get_random_perm.m
@@ -11,7 +11,7 @@ end
 
 % [ [1,2], [1,3], ..., [1, col], ..., [2,3], [2,4], ..., [2, col], ...
 % [col-1, col]
-matrix_all_perm_indexes = get_all_perm(n_max_comb, n_cols);
+matrix_all_perm_indexes = get_all_perm(n_cols);
 
 % choosing n_rows random indexes from 1 to n_max_comb
 array_random_rows_indexes = randperm(n_max_comb, n_rows);

--- a/get_total_perm.m
+++ b/get_total_perm.m
@@ -8,10 +8,9 @@ n_max_comb = 0;
 for i=1:n_cols-1
     n_max_comb = n_max_comb + i;
 end
-
 % [ [1,2], [1,3], ..., [1, col], ..., [2,3], [2,4], ..., [2, col], ...
 % [col-1, col]
-matrix_all_perm_indexes = get_all_perm(n_max_comb, n_cols);
+matrix_all_perm_indexes = get_all_perm(n_cols);
 
 % finding the resulting matrix
 matrix_final = zeros([n_max_comb, n_cols]);


### PR DESCRIPTION
## Summary
- Simplify get_all_perm to accept only column count
- Adjust get_random_perm and get_total_perm to use new get_all_perm signature

## Testing
- `octave --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68a11eceb18483308116bcb5e5857d61