### PR TITLE
Normalize total permutation matrix energy

### DIFF
--- a/get_total_perm.m
+++ b/get_total_perm.m
@@ -5,23 +5,26 @@ rng('shuffle');
 
 % max number of possible combinations for matrix B
 n_max_comb = 0;
-for i=1:n_cols-1
+for i = 1:n_cols-1
     n_max_comb = n_max_comb + i;
 end
-% [ [1,2], [1,3], ..., [1, col], ..., [2,3], [2,4], ..., [2, col], ...
-% [col-1, col]
+% [ [1,2], [1,3], ..., [col-1, col] ]
 matrix_all_perm_indexes = get_all_perm(n_cols);
 
 % finding the resulting matrix
 matrix_final = zeros([n_max_comb, n_cols]);
-for i=1:n_max_comb
+for i = 1:n_max_comb
     % setting 1 in the selected indexes
-    matrix_final(i,matrix_all_perm_indexes(i,1)) = 1;
-    matrix_final(i,matrix_all_perm_indexes(i,2)) = 1;
-    
-    % randomly choosing which one wil be -1
+    matrix_final(i, matrix_all_perm_indexes(i, 1)) = 1;
+    matrix_final(i, matrix_all_perm_indexes(i, 2)) = 1;
+
+    % randomly choosing which one will be -1
     negative_index = randi(2);
-    matrix_final(i,matrix_all_perm_indexes(i,negative_index)) = -1;
+    matrix_final(i, matrix_all_perm_indexes(i, negative_index)) = -1;
 end
 
+% Normalize to ensure unit energy per row
+matrix_final = (1/sqrt(2)) * matrix_final;
+
 end
+


### PR DESCRIPTION
## Summary
- Ensure total permutation matrices are energy-normalized by dividing by \(\sqrt{2}\)

## Testing
- `octave --eval "get_total_perm(4)"` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68a142a1cf9c8330bd5c0eda30b45ca8