### PR TITLE
Vectorized permutation creation and external RNG seeding

### DIFF
--- a/complejidad.m
+++ b/complejidad.m
@@ -1,5 +1,6 @@
 %% Measure average execution time for several selection strategies (full, random, CVX-based, greedy, SINR)
 clear all; close all; clc;
+rng('shuffle');
 
 %% Parámetros generales
 Nt = 4; Nr = 4;
@@ -12,7 +13,8 @@ channel_realizations = 4;
 %% Matrices base
 I_Nr_r = eye(2 * Nr);
 Cx_r = (1/2) * sigma_x^2 * eye(2 * Nt);
-B_all = get_total_perm(2 * Nr);
+seed_total_perm = randi(2^32-1);
+B_all = get_total_perm(2 * Nr, seed_total_perm);
 full = size(B_all, 1);
 M_prime_full = 2 * Nr + full;
 B_full = [I_Nr_r; B_all];
@@ -68,7 +70,8 @@ for i_channel = 1:channel_realizations
 
         %% Red Aleatoria
         A = tic;
-        B_rand_alpha = get_random_perm(alpha, 2 * Nr);
+        seed_rand_alpha = randi(2^32-1);
+        B_rand_alpha = get_random_perm(alpha, 2 * Nr, seed_rand_alpha);
         B_rand = [I_Nr_r; B_rand_alpha];
         Cz_r_rand = B_rand * (H_r * Cx_r * H_r') * B_rand' + B_rand * Cn_r * B_rand';
         k_r_rand = diag(1 ./ sqrt(diag(Cz_r_rand)));

--- a/get_random_perm.m
+++ b/get_random_perm.m
@@ -1,34 +1,34 @@
-function matrix_final = get_random_perm(n_rows, n_cols)
+function matrix_final = get_random_perm(n_rows, n_cols, seed)
+%GET_RANDOM_PERM Generate random signed pair combinations.
+%   MATRIX_FINAL = GET_RANDOM_PERM(N_ROWS, N_COLS, SEED) returns a matrix
+%   with N_ROWS randomly selected signed combinations of two columns out of
+%   N_COLS columns. When SEED is provided, the random number generator is
+%   initialised with this value for reproducibility.
 
-% random number generator
-rng('shuffle');
-
-% max number of possible combinations for matrix B
-n_max_comb = 0;
-for i=1:n_cols-1
-    n_max_comb = n_max_comb + i;
+if nargin > 2
+    rng(seed);
 end
 
-% [ [1,2], [1,3], ..., [1, col], ..., [2,3], [2,4], ..., [2, col], ...
-% [col-1, col]
-matrix_all_perm_indexes = get_all_perm(n_cols);
+% Max number of possible combinations for matrix B
+n_max_comb = n_cols * (n_cols - 1) / 2;
 
-% choosing n_rows random indexes from 1 to n_max_comb
+% Generate all combinations and select random rows
+matrix_all_perm_indexes = nchoosek(1:n_cols, 2);
 array_random_rows_indexes = randperm(n_max_comb, n_rows);
+selected_perm = matrix_all_perm_indexes(array_random_rows_indexes, :);
 
-% select just the combinations of the lines sorted above
-m_with_selected_perm_indexes = matrix_all_perm_indexes(array_random_rows_indexes, :);
+% Preallocate result matrix
+matrix_final = zeros(n_rows, n_cols);
 
-% finding the resulting matrix
-matrix_final = zeros([n_rows, n_cols]);
-for i=1:n_rows
-    % setting 1 in the selected indexes
-    matrix_final(i,m_with_selected_perm_indexes(i,1)) = 1;
-    matrix_final(i,m_with_selected_perm_indexes(i,2)) = 1;
-    
-    % randomly choosing which one wil be -1
-    negative_index = randi(2);
-    matrix_final(i,m_with_selected_perm_indexes(i,negative_index)) = -1;
+% Set ones for the selected indices using vectorisation
+rows = repelem((1:n_rows)', 2);
+cols = selected_perm(:);
+matrix_final(sub2ind([n_rows, n_cols], rows, cols)) = 1;
+
+% Randomly choose which index will be -1 for each row
+negative_choice = randi(2, n_rows, 1);
+negative_cols = selected_perm(sub2ind(size(selected_perm), (1:n_rows)', negative_choice));
+matrix_final(sub2ind([n_rows, n_cols], (1:n_rows)', negative_cols)) = -1;
+
 end
 
-end

--- a/get_total_perm.m
+++ b/get_total_perm.m
@@ -1,27 +1,33 @@
-function matrix_final = get_total_perm(n_cols)
+function matrix_final = get_total_perm(n_cols, seed)
+%GET_TOTAL_PERM Generate all signed pair combinations.
+%   MATRIX_FINAL = GET_TOTAL_PERM(N_COLS, SEED) returns a matrix with all
+%   possible signed combinations of two columns chosen from N_COLS columns.
+%   When SEED is provided, the random number generator is initialised with
+%   this value for reproducibility.
 
-% random number generator
-rng('shuffle');
-
-% max number of possible combinations for matrix B
-n_max_comb = 0;
-for i=1:n_cols-1
-    n_max_comb = n_max_comb + i;
-end
-% [ [1,2], [1,3], ..., [1, col], ..., [2,3], [2,4], ..., [2, col], ...
-% [col-1, col]
-matrix_all_perm_indexes = get_all_perm(n_cols);
-
-% finding the resulting matrix
-matrix_final = zeros([n_max_comb, n_cols]);
-for i=1:n_max_comb
-    % setting 1 in the selected indexes
-    matrix_final(i,matrix_all_perm_indexes(i,1)) = 1;
-    matrix_final(i,matrix_all_perm_indexes(i,2)) = 1;
-    
-    % randomly choosing which one wil be -1
-    negative_index = randi(2);
-    matrix_final(i,matrix_all_perm_indexes(i,negative_index)) = -1;
+if nargin > 1
+    rng(seed);
 end
 
+% Max number of possible combinations for matrix B
+n_max_comb = n_cols * (n_cols - 1) / 2;
+
+% Generate all combinations of two indices
+matrix_all_perm_indexes = nchoosek(1:n_cols, 2);
+
+% Preallocate result matrix
+matrix_final = zeros(n_max_comb, n_cols);
+
+% Set ones for the selected indices using vectorisation
+rows = repelem((1:n_max_comb)', 2);
+cols = matrix_all_perm_indexes(:);
+matrix_final(sub2ind([n_max_comb, n_cols], rows, cols)) = 1;
+
+% Randomly choose which index will be -1 for each row
+negative_choice = randi(2, n_max_comb, 1);
+negative_cols = matrix_all_perm_indexes(sub2ind(size(matrix_all_perm_indexes), ...
+    (1:n_max_comb)', negative_choice));
+matrix_final(sub2ind([n_max_comb, n_cols], (1:n_max_comb)', negative_cols)) = -1;
+
 end
+

--- a/untitled1.m
+++ b/untitled1.m
@@ -1,6 +1,7 @@
 clear all;
 close all;
 clc;
+rng('shuffle');
 %% Parámetros generales
 Nt = 4; Nr = 12;
 alpha = 2 * Nr;
@@ -29,10 +30,13 @@ constelation_points = exp(1i*pi*(2*(1:M)-1)/M);
 constelation_symbols = flipud((dec2bin(M-1:-1:0)-'0'));
 gray_code_data = gray_code(constelation_symbols,M);
 %% Matrices de comparación
- B_all = (1/sqrt(2)) * get_total_perm(2*Nr);
-B_rand = (1/sqrt(2)) * get_random_perm(alpha, 2 * Nr);
+seed_total_perm = randi(2^32-1);
+B_all = (1/sqrt(2)) * get_total_perm(2*Nr, seed_total_perm);
+seed_rand = randi(2^32-1);
+B_rand = (1/sqrt(2)) * get_random_perm(alpha, 2 * Nr, seed_rand);
 B_random_full = [I_Nr_r; B_rand];
-B_alpha_f = 1/sqrt(2) * get_random_perm(full, 2 * Nr);
+seed_alpha_f = randi(2^32-1);
+B_alpha_f = 1/sqrt(2) * get_random_perm(full, 2 * Nr, seed_alpha_f);
 B_full = [I_Nr_r; B_alpha_f];
 %% Simulación
 h_waitbar = waitbar(0, 'Iniciando simulación...');


### PR DESCRIPTION
## Summary
- Replace iterative combination count with analytic formula and vectorized construction in `get_total_perm` and `get_random_perm`
- Accept external RNG seeds and remove internal `rng('shuffle')` calls
- Update scripts to seed RNG once and pass seeds into permutation generators

## Testing
- `octave --version` *(fails: command not found)*
- `apt-get update` *(fails: repository access denied)*

------
https://chatgpt.com/codex/tasks/task_b_68a3a48b31208330a8f08028950478e5