### PR TITLE
Optimize matrix computations

### DIFF
--- a/greedy_search.m
+++ b/greedy_search.m
@@ -1,16 +1,21 @@
 function [final_W, final_B, K, Cz_r] = greedy_search(B_all, alpha, I_nr_r, Cn_r, H_r, Cx_r, n_max_comb)
+% Precompute constant matrices
+HCH = H_r * Cx_r * H_r';
+Cn_r_const = Cn_r;
+CxHrT_const = sqrt(pi/2)*(1/2) * Cx_r * H_r';
+
 % Alpha first rows of B_all
 B_alpha = B_all(1:alpha,:);
 % Computing the MSE for the first alpha rows
 new_B = [I_nr_r ; B_alpha];
-Cn_rand = new_B*Cn_r*new_B';
-K = diag(diag(new_B*H_r*Cx_r*H_r'*new_B'+Cn_rand).^(-1/2));
-%Czqx = sqrt(pi/2)*Cx_r*H_r'*new_B'*K;
-Czqx = sqrt(pi/2)*(1/2)*Cx_r*H_r'*new_B'*K;
+Cn_rand = new_B*Cn_r_const*new_B';
+HCH_newB = new_B*HCH*new_B';
+K = diag(diag(HCH_newB+Cn_rand).^(-1/2));
+Czqx = CxHrT_const*new_B'*K;
 
 % Compute Czq ensuring numerical stability
-Czq_matrix = asin(transpose(K) * real(new_B * H_r * Cx_r * H_r' * new_B' + Cn_rand) * K) ...
-    + 1i * asin(transpose(K) * imag(new_B * H_r * Cx_r * H_r' * new_B' + Cn_rand) * K);
+Czq_matrix = asin(transpose(K) * real(HCH_newB + Cn_rand) * K) ...
+    + 1i * asin(transpose(K) * imag(HCH_newB + Cn_rand) * K);
 
 if size(Czq_matrix, 1) == size(Czq_matrix, 2) && cond(Czq_matrix) < 1e10
     Czq = inv(Czq_matrix);
@@ -36,54 +41,80 @@ for i=1:alpha
     % Getting the rows that are not going to be permuted and freeze them
     B_frozen = B_alpha;
     B_frozen(i,:) = [];
+    % Precompute base matrices for fixed rows
+    row_idx = size(I_nr_r,1) + i;
+    Base_rows = [I_nr_r; B_frozen];
+    Base_HCH = Base_rows * HCH;
+    Base_C = Base_HCH * Base_rows';
+    Base_Cn = Base_rows * Cn_r_const * Base_rows';
+
     % Making the permutations in the row that was not freezed with the rows
     % that were not in the first B_alpha
     for j=1:n_max_comb
-    	% Checking if the j index is already in B_alpha
+        % Checking if the j index is already in B_alpha
         if opt_index_rows(1,j) == 1
             continue;
         end
         B_perm_row = B_all(j,:);
         B_result = [B_frozen(1:i-1,:); B_perm_row; B_frozen(i:end,:)];
-        
+
+        % Update only affected submatrices
+        cross_HCH = Base_HCH * B_perm_row';
+        self_HCH = B_perm_row * HCH * B_perm_row';
+        new_HCH = insert_row_col(Base_C, cross_HCH, self_HCH, row_idx);
+
+        cross_Cn = Base_rows * Cn_r_const * B_perm_row';
+        self_Cn = B_perm_row * Cn_r_const * B_perm_row';
+        Cw_r = insert_row_col(Base_Cn, cross_Cn, self_Cn, row_idx);
+
         % Computing the MSE value
         new_B = [I_nr_r ; B_result];
-        Cw_r = new_B*Cn_r*new_B';
-        
-        %K = diag(diag(new_B*H_r*Cx_r*H_r'*new_B'+Cw_r))^(-1/2);
-        K = diag(diag(new_B*H_r*Cx_r*H_r'*new_B'+Cw_r).^(-1/2));
-        %Czqx = sqrt(pi/2)*Cx_r*H_r'*new_B'*K;
-        Czqx = sqrt(pi/2)*(1/2)*Cx_r*H_r'*new_B'*K;
-        Czq = pinv(asin(transpose(K)*real(new_B*H_r*Cx_r*H_r'*new_B'+Cw_r)*K) + 1i*asin(transpose(K)*imag(new_B*H_r*Cx_r*H_r'*new_B'+Cw_r)*K));
+        K = diag(diag(new_HCH + Cw_r).^(-1/2));
+        Czqx = CxHrT_const*new_B'*K;
+        Czq = pinv(asin(transpose(K)*real(new_HCH + Cw_r)*K) + 1i*asin(transpose(K)*imag(new_HCH + Cw_r)*K));
         W = Czqx*Czq;
-        
+
         %equivalent objective MSE
         MSE_data = -2*real(trace(Czqx*W')) + trace(W*Czq*W');
-        
+
         %total MSE
         MSE_data_2 = trace(Cx_r) - 2*real(trace(Czqx*W')) + trace(W*Czq*W');
-        
+
         % Checking if the curent MSE is the minimum
         if MSE_data < lower_value
             lower_value = MSE_data;
             final_W = W;
             final_B = new_B;
             B_alpha = B_result;
-                        
+
             opt_index_rows(1,best_index) = 0;
             best_index = j;
             opt_index_rows(1,best_index) = 1;
         end
-        
+
         if MSE_data_2 < lower_value_2
             lower_value_2 = MSE_data_2;
         end
-        
+
       end
 
 end
 % Final Cz_r and K
-Cz_r = final_B*H_r*Cx_r*H_r'*final_B' + final_B*Cn_r*final_B';
+Cz_r = final_B*HCH*final_B' + final_B*Cn_r_const*final_B';
 K = diag(diag(Cz_r).^(-1/2));
 
+end
+
+function updated = insert_row_col(base, cross, self_val, idx)
+    n = size(base,1);
+    updated = zeros(n+1);
+    updated(1:idx-1,1:idx-1) = base(1:idx-1,1:idx-1);
+    updated(idx+1:end,idx+1:end) = base(idx:end,idx:end);
+    updated(1:idx-1,idx+1:end) = base(1:idx-1,idx:end);
+    updated(idx+1:end,1:idx-1) = base(idx:end,1:idx-1);
+    updated(1:idx-1,idx) = cross(1:idx-1);
+    updated(idx,1:idx-1) = cross(1:idx-1)';
+    updated(idx+1:end,idx) = cross(idx:end);
+    updated(idx,idx+1:end) = cross(idx:end)';
+    updated(idx,idx) = self_val;
 end

--- a/sinr_search.m
+++ b/sinr_search.m
@@ -2,6 +2,9 @@ function [W_SINR, B_seq_SINR, B_obtain,K_SINR, Cz_SINR, Czq_SINR] = sinr_search(
 
 
 cx_r=diag(Cx_r);
+HCH = H_r*Cx_r*H_r';
+Cn_r_const = Cn_r;
+HrCx = H_r*Cx_r;
  % Computing the SINR per virtual subchannel per signal component
        
         noise_matix = sigma_n^2 * ones(size(B_prime_f*H_r));
@@ -13,10 +16,10 @@ cx_r=diag(Cx_r);
         for i_alpha=1:alpha
        
             % MSE per subchannel        
-            Cn_r_SINR = B_seq_SINR*Cn_r*B_seq_SINR';
-            Cz_SINR = B_seq_SINR*H_r*Cx_r*H_r'*B_seq_SINR'+Cn_r_SINR;
+            Cn_r_SINR = B_seq_SINR*Cn_r_const*B_seq_SINR';
+            Cz_SINR = B_seq_SINR*HCH*B_seq_SINR'+Cn_r_SINR;
             K_SINR = diag(diag(Cz_SINR).^(-1/2));
-            Czqx_SINR = sqrt(2/pi)*K_SINR*B_seq_SINR*H_r*Cx_r;
+            Czqx_SINR = sqrt(2/pi)*K_SINR*B_seq_SINR*HrCx;
             Czq_SINR = 2/pi*(asin(K_SINR*real(Cz_SINR)*K_SINR));
             W_SINR = ((Czq_SINR)^(-1))*Czqx_SINR;
             % MSE per user signal
@@ -36,10 +39,10 @@ cx_r=diag(Cx_r);
        
         % LRA-MMSE optimized network
        
-            Cn_r_SINR = B_seq_SINR*Cn_r*B_seq_SINR';
-            Cz_SINR = B_seq_SINR*H_r*Cx_r*H_r'*B_seq_SINR'+Cn_r_SINR;
+            Cn_r_SINR = B_seq_SINR*Cn_r_const*B_seq_SINR';
+            Cz_SINR = B_seq_SINR*HCH*B_seq_SINR'+Cn_r_SINR;
             K_SINR = diag(diag(Cz_SINR).^(-1/2));
-            Czqx_SINR = sqrt(2/pi)*K_SINR*B_seq_SINR*H_r*Cx_r;
+            Czqx_SINR = sqrt(2/pi)*K_SINR*B_seq_SINR*HrCx;
             Czq_SINR = 2/pi*(asin(K_SINR*real(Cz_SINR)*K_SINR));
             W_SINR = ((Czq_SINR)^(-1))*Czqx_SINR;
        


### PR DESCRIPTION
## Summary
- Precompute H_r*Cx_r*H_r' and store reusable constants for efficiency.
- Incrementally update matrices in greedy_search to avoid full recomputation when rows change.
- Cache channel and noise products in SINR search for reuse.

## Testing
- `octave --version` *(fails: command not found)*
- `apt-get update` *(fails: 403 repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68a3a4f8d2d0833084beb90b28d6c066